### PR TITLE
Removed Sanctum HasApiToken Trait From User Model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,11 +7,10 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable implements JWTSubject
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasFactory, Notifiable;
 
     /**
      * The attributes that are mass assignable.


### PR DESCRIPTION
Sanctum HasApiToken trait removed from user model. 
This PR will fix `Trait "Laravel\Sanctum\HasApiTokens" not found` error in JQAdmin after login.